### PR TITLE
Don't use Object.prototpye.hasOwnProperty on query

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function should_pre_render (options) {
 
   // do pre-render when:
   var query = url.parse(options.url, true).query
-  if (query && query.hasOwnProperty('_escaped_fragment_')) return true
+  if (query && query['_escaped_fragment_'] !== undefined) return true
   if (options.bufferAgent) return true
 
   return is_bot(options.userAgent)


### PR DESCRIPTION
Don't use Object.prototpye.hasOwnProperty on object returned by querystring.parse

Since it does not inherit from Object.prototype since nodejs/node#6055 (node v6.0.0+)
