### PR TITLE
Remove require('is-bot')

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@
 
 var url = require('url')
 var axios = require('axios')
-var is_bot = require('is-bot')
 
 var extensions_to_ignore = [
   '.js',

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "author": "finbox.io",
   "license": "MIT",
   "dependencies": {
-    "axios": "0.9.1",
-    "is-bot": "0.0.1"
+    "axios": "0.9.1"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
It is getting used instead of our own is_bot function

For example, curl is getting "X-Prerender: true" when it should not
