### PR TITLE
Improves support for adaptive sites

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,12 @@ var crawlers = [
   'redditbot',
   'Applebot',
   'WhatsApp',
-  'flipboard'
+  'flipboard',
+  'duckduckbot',
+  'sogou',
+  'exabot',
+  'ia_archiver',
+  'facebot'
 ]
 
 var DEFAULT_PRERENDER = 'http://service.prerender.io/'

--- a/index.js
+++ b/index.js
@@ -127,6 +127,7 @@ module.exports = function pre_render_middleware (options) {
   return function * pre_render(next) {
     var protocol = options.protocol || this.protocol
     var host = options.host || this.host
+    var ua_passthrough = options.user_agent_passthrough
     var headers = { 'User-Agent': this.accept.headers['user-agent'] }
 
     var token = options.prerender_token || process.env.PRERENDER_TOKEN
@@ -136,6 +137,7 @@ module.exports = function pre_render_middleware (options) {
     var yes_pre_render = should_pre_render({
       userAgent: this.get('user-agent'),
       bufferAgent: this.get('x-bufferbot'),
+      prerenderAgent: ua_passthrough && this.get('x-prerender'),
       method: this.method,
       url: this.url
     })

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
 
 var url = require('url')
 var axios = require('axios')
+var debug = process.env.DEBUG
 
 var extensions_to_ignore = [
   '.js',
@@ -147,12 +148,12 @@ module.exports = function pre_render_middleware (options) {
         url: pre_render_url,
         headers: headers
       }).catch((e) => {
-        console.error(e)
+        if (debug) console.error(e.message)
         return { data: '' }
       })
 
       var body = response.data
-      if (!body) console.error('No response received :(')
+      if (!body && debug) console.error('No response received :(')
       if (options.log) console.log('pre-render...%s, %s', render_url, JSON.stringify(headers))
 
       yield* next

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "koa": "1.2.1",
-    "mocha": "2.5.3",
-    "supertest": "2.0.0"
+    "koa": "1.2.5",
+    "mocha": "3.2.0",
+    "supertest": "3.0.0"
   },
   "engines": {
     "node": ">= 4.2.1",

--- a/test.js
+++ b/test.js
@@ -11,49 +11,54 @@ describe('Koa prerender middleware', function() {
   })
 
   describe('prerenders when', function() {
-
     it('url contains _escaped_fragment_', function (done) {
       var app = koa()
-
       app.use(prerender())
 
-      request(app.listen())
+      var server = app.listen()
+      request(server)
         .get('/?_escaped_fragment_')
         .expect('X-Prerender', 'true')
-        .expect(200, done)
+        .expect(200, function () {
+          server.close()
+          done()
+        })
     })
 
     it('user-agent looks like a bot', function (done) {
       var app = koa()
-
       app.use(prerender())
 
-      request(app.listen())
+      var server = app.listen()
+      request(server)
         .get('/')
         .set('user-agent', 'slackbot')
         .expect('X-Prerender', 'true')
-        .expect(200, () => {
-          request(app.listen())
+        .expect(200, function () {
+          request(server)
             .get('/')
             .set('user-agent', 'YandexBot')
             .expect('X-Prerender', 'true')
-            .expect(200, done)
+            .expect(200, function () {
+              server.close()
+              done()
+            })
         })
     })
 
     it('x-bufferbot is set in options', function (done) {
       var app = koa()
-
       app.use(prerender())
 
-      request(app.listen())
+      var server = app.listen()
+      request(server)
         .get('/')
         .set('x-bufferbot', 'whatever')
         .expect('X-Prerender', 'true')
-        .expect(200, done)
-
+        .expect(200, function () {
+          server.close()
+          done()
+        })
     })
-
   })
-
 })


### PR DESCRIPTION
For more information, reference: https://github.com/prerender/prerender/issues/191

Current middleware fails mobile-friendly test for google for adaptive sites (sites that render content differently for mobile devices by detecting user agent server side)

Other checks before upgrading to this middleware:
- Make sure that you aren't checking for Googlebot by their user agent since that could get you penalized for cloaking. 
- Make sure that you have <meta name="fragment" content="!"> in the <head> of your pages and Googlebot will request the ?escaped_fragment= URLs.
- Email Todd so he can start forwarding the original user agent through.
